### PR TITLE
Supported gcloud 0.9.65

### DIFF
--- a/script/cluster
+++ b/script/cluster
@@ -62,7 +62,7 @@ push_image() {
   echo
 
   echo "=== Push docker image ==="
-  gcloud preview docker push $IMAGE_TAG
+  gcloud docker push $IMAGE_TAG
   echo
 }
 


### PR DESCRIPTION
From the release notes 0.9.65 (2015/06/17):
https://dl.google.com/dl/cloudsdk/release/RELEASE_NOTES
`gcloud preview docker moved to gcloud docker.`
